### PR TITLE
FIX: Ignore key when present in `class_weight` and not in labels

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -58,9 +58,11 @@ def compute_class_weight(class_weight, *, classes, y):
             raise ValueError(
                 "class_weight must be dict, 'balanced', or None, got: %r" % class_weight
             )
-        for c in class_weight:
+
+        # Ignore class weights that are not in y
+        for c in y:
             i = np.searchsorted(classes, c)
-            if i >= len(classes) or classes[i] != c:
+            if i >= len(classes) or classes[i] != c or c not in class_weight:
                 raise ValueError("Class label {} not present.".format(c))
             else:
                 weight[i] = class_weight[c]

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -30,7 +30,7 @@ def test_compute_class_weight_not_present():
         compute_class_weight("balanced", classes=classes, y=y)
     # Fix exception in error message formatting when missing label is a string
     # https://github.com/scikit-learn/scikit-learn/issues/8312
-    with pytest.raises(ValueError, match="Class label label_not_present not present"):
+    with pytest.raises(ValueError, match="Class label 0 not present"):
         compute_class_weight({"label_not_present": 1.0}, classes=classes, y=y)
     # Raise error when y has items not in classes
     classes = np.arange(2)
@@ -54,13 +54,17 @@ def test_compute_class_weight_dict():
     # should get raised
     msg = "Class label 4 not present."
     class_weights = {0: 1.0, 1: 2.0, 2: 3.0, 4: 1.5}
-    with pytest.raises(ValueError, match=msg):
+
+    try:
         compute_class_weight(class_weights, classes=classes, y=y)
+    except ValueError:
+        pytest.fail(msg)
 
     msg = "Class label -1 not present."
-    class_weights = {-1: 5.0, 0: 1.0, 1: 2.0, 2: 3.0}
-    with pytest.raises(ValueError, match=msg):
+    try:
         compute_class_weight(class_weights, classes=classes, y=y)
+    except ValueError:
+        pytest.fail(msg)
 
 
 def test_compute_class_weight_invariance():
@@ -129,19 +133,16 @@ def test_compute_class_weight_default():
     classes = np.unique(y)
     classes_len = len(classes)
 
-    # Test for non specified weights
     cw = compute_class_weight(None, classes=classes, y=y)
     assert len(cw) == classes_len
     assert_array_almost_equal(cw, np.ones(3))
 
     # Tests for partly specified weights
-    cw = compute_class_weight({2: 1.5}, classes=classes, y=y)
-    assert len(cw) == classes_len
-    assert_array_almost_equal(cw, [1.5, 1.0, 1.0])
+    with pytest.raises(ValueError):
+       compute_class_weight({2: 1.5}, classes=classes, y=y)
 
-    cw = compute_class_weight({2: 1.5, 4: 0.5}, classes=classes, y=y)
-    assert len(cw) == classes_len
-    assert_array_almost_equal(cw, [1.5, 1.0, 0.5])
+    with pytest.raises(ValueError):
+       compute_class_weight({2: 1.5, 4: 0.5}, classes=classes, y=y)
 
 
 def test_compute_sample_weight():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Fixes: #1 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

As mentioned in this comment https://github.com/scikit-learn/scikit-learn/issues/22413#issuecomment-1034134279, class weights not in `y` (labels) are now ignored. But class weights in `y` that are *not* present in `class_weight` will raise a ValueError.

#### Any other comments?

**TODO**:

- [x] Unit Testing
- [x] CAT Testing

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
