### PR TITLE
FIX: Allow `pipeline` to handle `fit` and `transform` and allows adding `tSNE`

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -221,7 +221,6 @@ class Pipeline(_BaseComposition):
             and estimator != "passthrough"
             and not hasattr(estimator, "fit")
         ):
-            print(estimator)
             raise TypeError(
                 "Last step of Pipeline should implement fit, "
                 "fit_transform, or be the string 'passthrough'. "

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -172,14 +172,16 @@ def test_pipeline_invalid_parameters():
     with pytest.raises(TypeError):
         pipeline.fit([[1]], [1])
 
+    nofit = NoFit()
     # Check that we can't fit pipelines with objects without fit
     # method
-    msg = (
-        "Last step of Pipeline should implement fit "
-        "or be the string 'passthrough'"
-        ".*NoFit.*"
+    msg = re.escape(
+        "Last step of Pipeline should implement fit, "
+        "fit_transform, or be the string 'passthrough'. "
+        "'%s' (type %s) doesn't" % (nofit, type(nofit))
     )
-    pipeline = Pipeline([("clf", NoFit())])
+
+    pipeline = Pipeline([("clf", nofit)])
     with pytest.raises(TypeError, match=msg):
         pipeline.fit([[1]], [1])
 
@@ -654,9 +656,8 @@ def test_set_pipeline_steps():
 
     # With invalid data
     pipeline.set_params(steps=[("junk", ())])
-    msg = re.escape(
-        "Last step of Pipeline should implement fit or be the string 'passthrough'."
-    )
+    msg = re.escape("Last step of Pipeline should implement fit, fit_transform, or be the string 'passthrough'. '()' (type <class 'tuple'>) doesn't")
+
     with pytest.raises(TypeError, match=msg):
         pipeline.fit([[1]], [1])
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Closes #4 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Currently, the pipeline feature does not allow users to insert tSNE dimensionality reduction algorithm into a pipeline. This is because it only allows transformers with the "transform" and either one of "fit" or "fit_transform" methods, and since tSNE only has the "fit_transform" method, it fails that sanity test and causes an error. This is done because by adding tSNE to pipeline it makes it essentially a single pass, however, a user should have the option of creating a single pass pipeline.

I fixed this by added a new sanity check, which checked that either "fit_transform" or both "fit" and "transform" are present, which removes this issue and allows users to add tSNE to their pipeline. Rather than an error, we now return a warning that an intermediate step does not have transform. 

#### Any other comments?

I also changed a similar error message  which ensured the last estimator in the pipeline may also contain "fit_transform" 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
