### PR TITLE
[FIX] Return consistent best index given ties for `BaseSearchCV`

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -745,6 +745,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             if len(min_rank_indices) == 1:
                 # Store the only best index, further computation need not be necessary
                 best_index = min_rank_indices[0]
+                return best_index
             else:
                 """
                 Get the parameter values. Note keys are prefixed with 'param_'

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2450,3 +2450,23 @@ def test_grid_search_various_combinations_same_rank():
 
     pairs = zip(to_compare, to_compare)
     assert all(True if x==y else False for x,y in pairs)
+
+def test_grid_search_various_combinations_same_rank_randomized_search_cv():
+    """
+    Test grid with parameters passed in different orders. Verify result is returned based on lexicographical precedence.
+    """
+    iris = load_iris()
+    list_of_params = [
+        {'kernel': ('linear', 'rbf'),'C': [7, 1]}, 
+        {'kernel': ('linear', 'rbf'), 'C':[1, 7]},
+        {'kernel': ('rbf', 'linear'), 'C': [7, 1]}, 
+        {'kernel': ('rbf', 'linear'), 'C':[1, 7]}
+    ] 
+    to_compare = []
+    for element in list_of_params:
+        clf = RandomizedSearchCV( estimator=SVC(), n_iter=3, param_distributions=element, return_train_score=True )
+        clf.fit(X=iris.data, y=iris.target)
+        to_compare.append(clf.best_params_)
+
+    pairs = zip(to_compare, to_compare)
+    assert all(True if x==y else False for x,y in pairs)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -8,6 +8,7 @@ import pickle
 import sys
 from types import GeneratorType
 import re
+from sklearn.datasets import load_iris
 
 import numpy as np
 import scipy.sparse as sp
@@ -2409,3 +2410,43 @@ def test_search_cv_verbose_3(capsys, return_train_score):
     else:
         match = re.findall(r"score=[\d\.]+", captured)
     assert len(match) == 3
+
+@pytest.mark.parametrize(
+    "expected",
+    [
+        ({'regressor': LinearRegression()})
+    ],
+)
+def test_grid_search_combinations_with_regressors(expected):
+    """
+    Test grid search with regressors passed in as parameters in various orders. Return should be based on lexicographical precedence.
+    """
+
+    pipe = Pipeline([("regressor", LinearRegression())])
+    param_grid = {"regressor": [LinearRegression(), Ridge()]}
+    grid_search = GridSearchCV(pipe, param_grid, cv=2)
+    grid_search.fit(X, y)
+    # Unable to check for equality of two objects as python checks for same address as well
+    # So checking string representative lets us know if the correct one was returned back
+    assert str(grid_search.best_params_) == str(expected)
+
+
+def test_grid_search_various_combinations_same_rank():
+    """
+    Test grid with parameters passed in different orders. Verify result is returned based on lexicographical precedence.
+    """
+    iris = load_iris()
+    list_of_params = [
+        {'kernel': ('linear', 'rbf'),'C': [7, 1]}, 
+        {'kernel': ('linear', 'rbf'), 'C':[1, 7]},
+        {'kernel': ('rbf', 'linear'), 'C': [7, 1]}, 
+        {'kernel': ('rbf', 'linear'), 'C':[1, 7]}
+    ] 
+    to_compare = []
+    for element in list_of_params:
+        clf = GridSearchCV(estimator=SVC(), param_grid=element, return_train_score=True)
+        clf.fit(X=iris.data, y=iris.target)
+        to_compare.append(clf.best_params_)
+
+    pairs = zip(to_compare, to_compare)
+    assert all(True if x==y else False for x,y in pairs)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes: #7

#### What does this implement/fix? Explain your changes.

As mentioned in #21895, the issue is when there is a tie for `mean_test_score`. Suppose there are 2 values with a minimum `rank_test_score`, for example 1. The problem arises when the ordering of the parameters changes, as that currently affects which index gets picked. Of course, this is clearly not ideal and not consistent, we want the same output given the same input.

The most ideal solution, and which is what is currently implemented in this PR, is to perform a lexicographical sort of the values whose rank is of minimum rank, and return the first index corresponding to the first value of the sorted values.

**TODO**: 

- [x] ~~@Samyakk123~~ Please reword the description
- [x] Add appropriate unit tests to cover said case

**To test**:

```python
from sklearn import svm, datasets
import pandas as pd
import numpy as np
from sklearn.model_selection import GridSearchCV
iris = datasets.load_iris()
def grid_search(parameters):
    svc = svm.SVC()
    clf = GridSearchCV(svc, parameters,return_train_score=True)
    clf.fit(iris.data, iris.target)
    print(pd.DataFrame(clf.cv_results_)[['param_C','param_kernel','mean_test_score','rank_test_score','mean_train_score']])
    print('best_parameters = ',clf.best_params_,'\n')

params = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
grid_search(params)
params = {'kernel':('rbf', 'linear'), 'C':[10, 1]}
grid_search(params)
```

**Expected**:

```python
best_parameters =  {'C': 1, 'kernel': 'linear'} 
best_parameters =  {'C': 1, 'kernel': 'linear'} 
```
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
